### PR TITLE
Fix width of certain characters (ref #22)

### DIFF
--- a/APL387.ufo2/glyphs/uni2218.glif
+++ b/APL387.ufo2/glyphs/uni2218.glif
@@ -4,7 +4,6 @@
   <unicode hex="2218"/>
   <outline>
     <contour>
-      <point x="367.5" y="489"/>
       <point x="462.5" y="391"/>
       <point x="462.5" y="322" type="qcurve" smooth="yes"/>
       <point x="462.5" y="257"/>
@@ -14,9 +13,9 @@
       <point x="137.5" y="322" type="qcurve" smooth="yes"/>
       <point x="137.5" y="391"/>
       <point x="233.5" y="489"/>
+      <point x="367.5" y="489"/>
     </contour>
     <contour>
-      <point x="266.5" y="409"/>
       <point x="217.5" y="358"/>
       <point x="217.5" y="322" type="qcurve" smooth="yes"/>
       <point x="217.5" y="290"/>
@@ -26,6 +25,7 @@
       <point x="383.5" y="322" type="qcurve" smooth="yes"/>
       <point x="383.5" y="358"/>
       <point x="334.5" y="409"/>
+      <point x="266.5" y="409"/>
     </contour>
   </outline>
 </glyph>

--- a/APL387.ufo2/glyphs/uni235B_.glif
+++ b/APL387.ufo2/glyphs/uni235B_.glif
@@ -4,7 +4,6 @@
   <unicode hex="235B"/>
   <outline>
     <contour>
-      <point x="367.5" y="489"/>
       <point x="462.5" y="391"/>
       <point x="462.5" y="322" type="qcurve" smooth="yes"/>
       <point x="462.5" y="257"/>
@@ -14,9 +13,9 @@
       <point x="137.5" y="322" type="qcurve" smooth="yes"/>
       <point x="137.5" y="391"/>
       <point x="233.5" y="489"/>
+      <point x="367.5" y="489"/>
     </contour>
     <contour>
-      <point x="266.5" y="409"/>
       <point x="217.5" y="358"/>
       <point x="217.5" y="322" type="qcurve" smooth="yes"/>
       <point x="217.5" y="290"/>
@@ -26,6 +25,7 @@
       <point x="383.5" y="322" type="qcurve" smooth="yes"/>
       <point x="383.5" y="358"/>
       <point x="334.5" y="409"/>
+      <point x="266.5" y="409"/>
     </contour>
     <contour>
       <point x="83" y="-95" type="qcurve" smooth="yes"/>

--- a/APL387.ufo2/glyphs/uni2364.glif
+++ b/APL387.ufo2/glyphs/uni2364.glif
@@ -32,7 +32,6 @@
       <point x="379" y="785"/>
     </contour>
     <contour>
-      <point x="367.5" y="489"/>
       <point x="462.5" y="391"/>
       <point x="462.5" y="322" type="qcurve" smooth="yes"/>
       <point x="462.5" y="257"/>
@@ -42,9 +41,9 @@
       <point x="137.5" y="322" type="qcurve" smooth="yes"/>
       <point x="137.5" y="391"/>
       <point x="233.5" y="489"/>
+      <point x="367.5" y="489"/>
     </contour>
     <contour>
-      <point x="266.5" y="409"/>
       <point x="217.5" y="358"/>
       <point x="217.5" y="322" type="qcurve" smooth="yes"/>
       <point x="217.5" y="290"/>
@@ -54,6 +53,7 @@
       <point x="383.5" y="322" type="qcurve" smooth="yes"/>
       <point x="383.5" y="358"/>
       <point x="334.5" y="409"/>
+      <point x="266.5" y="409"/>
     </contour>
   </outline>
 </glyph>

--- a/APL387.ufo2/glyphs/uni25F_4.glif
+++ b/APL387.ufo2/glyphs/uni25F_4.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni25F4" format="1">
-  <advance width="623"/>
+  <advance width="600"/>
   <unicode hex="25F4"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/wgrave.glif
+++ b/APL387.ufo2/glyphs/wgrave.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="wgrave" format="1">
-  <advance width="542"/>
+  <advance width="600"/>
   <unicode hex="1E81"/>
   <outline>
     <contour>


### PR DESCRIPTION
I don't know whether this will fix the issue, but it's certainly a step in the right direction. Wonder how it happened that these specific two glyphs had their width slightly wrong.