### PR TITLE
Remove empty bold digits

### DIFF
--- a/APL387.ufo2/features.fea
+++ b/APL387.ufo2/features.fea
@@ -727,7 +727,6 @@ feature mkmk {
       lookup mkmkMarktoMarklookup5;
       lookup mkmkMarktoMarklookup6;
 } mkmk;
-#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\.null \nonmarkingreturn \space \exclam \quotedbl \numbersign 
 	\dollar \percent \ampersand \quotesingle \parenleft \parenright \asterisk \plus 
@@ -857,8 +856,7 @@ feature mkmk {
 	\uni211A \uni2124 \u1D538 \u1D539 \u1D53B \u1D53C \u1D540 \u1D541 \u1D542 \u1D543 
 	\u1D544 \u1D546 \u1D54B \u1D54C \u1D54D \u1D550 \u1D552 \u1D553 \u1D554 \u1D555 
 	\u1D556 \u1D559 \u1D55A \u1D55B \u1D55C \u1D55D \u1D55E \u1D55F \u1D560 \u1D561 
-	\u1D562 \u1D565 \u1D566 \u1D567 \u1D56A \u1D56B \u1D7CE \u1D7CF \u1D7D0 \u1D7D1 
-	\u1D7D2 \u1D7D3 \u1D7D4 \u1D7D5 \u1D7D6 \u1D7D7 \uni23E8 \uni1D0A \uni21C7 
+	\u1D562 \u1D565 \u1D566 \u1D567 \u1D56A \u1D56B \uni23E8 \uni1D0A \uni21C7 
 	\uni219A \filledbox \H22073 \uni298B \uni298C \uni223B \uni2E20 \uni2E21 
 	\uni2221 \Rfraktur \Ifraktur \uni22B2 \uni22B3 \uni22B4 \uni22B5 \uni21C2 
 	\uni21BE \uni2A33 \uni22F5 \uni29FA \uni2D67 \uni07F9 \twodotenleader \uni2AC7 

--- a/APL387.ufo2/fontinfo.plist
+++ b/APL387.ufo2/fontinfo.plist
@@ -29,7 +29,7 @@
     <key>italicAngle</key>
     <real>0</real>
     <key>openTypeHeadCreated</key>
-    <string>2025/07/10 10:13:16</string>
+    <string>2025/07/10 12:12:18</string>
     <key>openTypeHheaAscender</key>
     <integer>910</integer>
     <key>openTypeHheaDescender</key>


### PR DESCRIPTION
When double struck digits were moved to their right place in #33, the bold digits still remained in the font as empty glyphs.