### PR TITLE
Fix wrong advances for some glyphs

### DIFF
--- a/APL387.ufo2/fontinfo.plist
+++ b/APL387.ufo2/fontinfo.plist
@@ -29,7 +29,7 @@
     <key>italicAngle</key>
     <real>0</real>
     <key>openTypeHeadCreated</key>
-    <string>2026/04/21 10:43:02</string>
+    <string>2026/04/24 15:08:12</string>
     <key>openTypeHheaAscender</key>
     <integer>910</integer>
     <key>openTypeHheaDescender</key>
@@ -133,6 +133,6 @@
     <key>postscriptUnderlinePosition</key>
     <integer>-125</integer>
     <key>postscriptIsFixedPitch</key>
-    <false/>
+    <true/>
   </dict>
 </plist>

--- a/APL387.ufo2/glyphs/C_commaaccent.glif
+++ b/APL387.ufo2/glyphs/C_commaaccent.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="Ccommaaccent" format="1">
-  <advance width="621"/>
+  <advance width="600"/>
   <outline>
     <contour>
       <point x="311" y="0" type="move" name="Anchor0"/>

--- a/APL387.ufo2/glyphs/nonmarkingreturn.glif
+++ b/APL387.ufo2/glyphs/nonmarkingreturn.glif
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nonmarkingreturn" format="1">
-  <advance width="333"/>
+  <advance width="600"/>
 </glyph>

--- a/APL387.ufo2/glyphs/omega.glif
+++ b/APL387.ufo2/glyphs/omega.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="omega" format="1">
-  <advance width="599"/>
+  <advance width="600"/>
   <unicode hex="03C9"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/uni006A_0301.glif
+++ b/APL387.ufo2/glyphs/uni006A_0301.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni006A0301" format="1">
-  <advance width="590"/>
+  <advance width="600"/>
   <outline>
     <contour>
       <point x="220" y="906" type="move" name="Anchor7"/>

--- a/APL387.ufo2/glyphs/uni03A_9.glif
+++ b/APL387.ufo2/glyphs/uni03A_9.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni03A9" format="1">
-  <advance width="599"/>
+  <advance width="600"/>
   <unicode hex="03A9"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/uni03F_8.glif
+++ b/APL387.ufo2/glyphs/uni03F_8.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni03F8" format="1">
-  <advance width="599"/>
+  <advance width="600"/>
   <unicode hex="03F8"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/uni040F_.glif
+++ b/APL387.ufo2/glyphs/uni040F_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni040F" format="1">
-  <advance width="599"/>
+  <advance width="600"/>
   <unicode hex="040F"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/uni044F_.001.glif
+++ b/APL387.ufo2/glyphs/uni044F_.001.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni044F.001" format="1">
-  <advance width="512"/>
+  <advance width="600"/>
   <outline>
     <contour>
       <point x="235" y="398" type="line" smooth="yes"/>

--- a/APL387.ufo2/glyphs/uni227A_.glif
+++ b/APL387.ufo2/glyphs/uni227A_.glif
@@ -49,8 +49,7 @@
       <point x="140.7" y="286.34" type="qcurve" smooth="yes"/>
       <point x="141.573" y="286.127"/>
       <point x="142.481" y="285.949" type="qcurve" smooth="yes"/>
-      <point x="142.481" y="285.949"/>
-      <point x="163.279" y="282.975" type="qcurve" smooth="yes"/>
+      <point x="163.279" y="282.975" type="line" smooth="yes"/>
       <point x="184.077" y="280"/>
       <point x="249.541" y="258.249"/>
       <point x="320.376" y="224.822"/>

--- a/APL387.ufo2/glyphs/uni22C_E_.glif
+++ b/APL387.ufo2/glyphs/uni22C_E_.glif
@@ -49,8 +49,7 @@
       <point x="334.463" y="171.469" type="qcurve" smooth="yes"/>
       <point x="334.677" y="172.343"/>
       <point x="334.854" y="173.25" type="qcurve" smooth="yes"/>
-      <point x="334.854" y="173.25"/>
-      <point x="337.828" y="194.048" type="qcurve" smooth="yes"/>
+      <point x="337.828" y="194.048" type="line" smooth="yes"/>
       <point x="340.803" y="214.846"/>
       <point x="362.555" y="280.311"/>
       <point x="395.98" y="351.146"/>


### PR DESCRIPTION
I don't believe this is a fix for #22 since the combining accent characters are still 0-wide, which Windows still doesn't like.