### PR TITLE
Vertically align ? stem with ! stem

### DIFF
--- a/APL387.ufo2/fontinfo.plist
+++ b/APL387.ufo2/fontinfo.plist
@@ -29,7 +29,7 @@
     <key>italicAngle</key>
     <real>0</real>
     <key>openTypeHeadCreated</key>
-    <string>2026/04/24 15:08:12</string>
+    <string>2026/04/28 14:43:59</string>
     <key>openTypeHheaAscender</key>
     <integer>910</integer>
     <key>openTypeHheaDescender</key>

--- a/APL387.ufo2/glyphs/question.glif
+++ b/APL387.ufo2/glyphs/question.glif
@@ -4,37 +4,36 @@
   <unicode hex="003F"/>
   <outline>
     <contour>
-      <point x="158" y="600" type="qcurve" smooth="yes"/>
-      <point x="217" y="659"/>
-      <point x="299" y="659" type="qcurve" smooth="yes"/>
-      <point x="370" y="659"/>
-      <point x="453" y="577"/>
-      <point x="453" y="503" type="qcurve" smooth="yes"/>
-      <point x="453" y="461"/>
-      <point x="409" y="374"/>
-      <point x="357" y="314"/>
-      <point x="312" y="242"/>
-      <point x="311" y="213" type="qcurve" smooth="yes"/>
-      <point x="310" y="162"/>
-      <point x="266" y="162" type="qcurve" smooth="yes"/>
-      <point x="222" y="162"/>
-      <point x="224" y="214" type="qcurve" smooth="yes"/>
-      <point x="225" y="253"/>
-      <point x="270" y="331"/>
-      <point x="322" y="386"/>
-      <point x="365" y="464"/>
-      <point x="365" y="502" type="qcurve" smooth="yes"/>
-      <point x="365" y="532"/>
-      <point x="328" y="574"/>
-      <point x="302" y="574" type="qcurve" smooth="yes"/>
-      <point x="254" y="574"/>
-      <point x="223" y="542" type="qcurve" smooth="yes"/>
-      <point x="188" y="506"/>
-      <point x="156" y="535" type="qcurve" smooth="yes"/>
-      <point x="122" y="564"/>
+      <point x="158" y="648" type="qcurve" smooth="yes"/>
+      <point x="217" y="707"/>
+      <point x="299" y="707" type="qcurve" smooth="yes"/>
+      <point x="370" y="707"/>
+      <point x="453" y="625"/>
+      <point x="453" y="551" type="qcurve" smooth="yes"/>
+      <point x="453" y="509"/>
+      <point x="409" y="422"/>
+      <point x="357" y="362"/>
+      <point x="312" y="290"/>
+      <point x="311" y="261" type="qcurve" smooth="yes"/>
+      <point x="310" y="210"/>
+      <point x="266" y="210" type="qcurve" smooth="yes"/>
+      <point x="222" y="210"/>
+      <point x="224" y="262" type="qcurve" smooth="yes"/>
+      <point x="225" y="301"/>
+      <point x="270" y="379"/>
+      <point x="322" y="434"/>
+      <point x="365" y="512"/>
+      <point x="365" y="550" type="qcurve" smooth="yes"/>
+      <point x="365" y="580"/>
+      <point x="328" y="622"/>
+      <point x="302" y="622" type="qcurve" smooth="yes"/>
+      <point x="254" y="622"/>
+      <point x="223" y="590" type="qcurve" smooth="yes"/>
+      <point x="188" y="554"/>
+      <point x="156" y="583" type="qcurve" smooth="yes"/>
+      <point x="122" y="612"/>
     </contour>
     <contour>
-      <point x="236" y="-10"/>
       <point x="199" y="27"/>
       <point x="199" y="79"/>
       <point x="236" y="116"/>
@@ -42,6 +41,7 @@
       <point x="325" y="79"/>
       <point x="325" y="27"/>
       <point x="288" y="-10"/>
+      <point x="236" y="-10"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
Fixes #101

As mentioned in the issue, I believe raising the ? stem up is enough to make it not look odd next to !, if you want I can shorten the ! stem (or enlarge the ? stem, with some work) too

<img width="575" height="163" alt="image" src="https://github.com/user-attachments/assets/620060bd-c4b1-46a5-bd46-34317468ac46" />
