### PR TITLE
Add a variant of ⏨ for ss01 (fixes #87)

### DIFF
--- a/APL387.ufo2/features.fea
+++ b/APL387.ufo2/features.fea
@@ -24,6 +24,7 @@ lookup ss01StyleSet1lookup1 {
     sub \zero by \zero_ss01 ;
     sub \uni2070 by \sup_zero_ss01 ;
     sub \uni2080 by \sub_zero_ss01 ;
+    sub \uni23E8 by \uni23E8_ss01 ;
 } ss01StyleSet1lookup1;
 
 lookup ss02StyleSet2lookup2 {
@@ -950,7 +951,7 @@ feature mkmk {
 	\uni2242 \uni2243 \congruent \uni2246 \uni2247 \uni224A \uni224C \uni2251 
 	\uni2252 \uni2253 \uni225C \uni227A \uni227B \uni227C \uni227D \uni227E \uni227F 
 	\uni2280 \uni2281 \uni22CE \uni22CF \uni22DE \uni22DF \uni2AAA \uni2AAB \uni2AAC 
-	\uni2AAD \uni2AAF \uni2AB0 \uni214B ];
+	\uni2AAD \uni2AAF \uni2AB0 \uni214B \uni23E8_ss01 ];
 @GDEF_Mark = [\gravecomb \acutecomb \uni0302 \tildecomb \uni0304 \uni0305 \uni0306 
 	\uni0307 \uni0308 \uni030A \uni030B \uni030C \uni0326 \uni0327 \uni0328 
 	\uni0302.alt01 \uni0304.alt01 \uni0308.case \uni0307.case \gravecomb.case 

--- a/APL387.ufo2/fontinfo.plist
+++ b/APL387.ufo2/fontinfo.plist
@@ -29,7 +29,7 @@
     <key>italicAngle</key>
     <real>0</real>
     <key>openTypeHeadCreated</key>
-    <string>2026/04/28 14:43:59</string>
+    <string>2026/04/30 14:57:32</string>
     <key>openTypeHheaAscender</key>
     <integer>910</integer>
     <key>openTypeHheaDescender</key>

--- a/APL387.ufo2/glyphs/contents.plist
+++ b/APL387.ufo2/glyphs/contents.plist
@@ -2958,5 +2958,7 @@
     <string>uni2A_B_0.glif</string>
     <key>uni214B</key>
     <string>uni214B_.glif</string>
+    <key>uni23E8_ss01</key>
+    <string>uni23E_8_ss01.glif</string>
   </dict>
 </plist>

--- a/APL387.ufo2/glyphs/uni23E_8_ss01.glif
+++ b/APL387.ufo2/glyphs/uni23E_8_ss01.glif
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni23E8_ss01" format="1">
+  <advance width="600"/>
+  <outline>
+    <contour>
+      <point x="400" y="281" type="qcurve" smooth="yes"/>
+      <point x="462" y="281"/>
+      <point x="556" y="166"/>
+      <point x="556" y="-10.0005"/>
+      <point x="462" y="-125"/>
+      <point x="400" y="-125" type="qcurve" smooth="yes"/>
+      <point x="363.005" y="-125"/>
+      <point x="331.367" y="-105.18" type="qcurve" smooth="yes"/>
+      <point x="331.26" y="-105.278"/>
+      <point x="330.674" y="-105.85"/>
+      <point x="330.5" y="-106" type="qcurve" smooth="yes"/>
+      <point x="320" y="-115"/>
+      <point x="310" y="-115" type="qcurve" smooth="yes"/>
+      <point x="85" y="-115" type="line" smooth="yes"/>
+      <point x="74.0005" y="-115"/>
+      <point x="53" y="-96.0005"/>
+      <point x="53" y="-83" type="qcurve" smooth="yes"/>
+      <point x="53" y="-69.0005"/>
+      <point x="73.0005" y="-51.9995"/>
+      <point x="85" y="-52" type="qcurve" smooth="yes"/>
+      <point x="169" y="-52" type="line"/>
+      <point x="169" y="155" type="line"/>
+      <point x="132" y="109" type="line" smooth="yes"/>
+      <point x="123" y="97"/>
+      <point x="95.0005" y="97"/>
+      <point x="85" y="107" type="qcurve" smooth="yes"/>
+      <point x="62.0005" y="128"/>
+      <point x="83" y="152" type="qcurve" smooth="yes"/>
+      <point x="175" y="253" type="line" smooth="yes"/>
+      <point x="193" y="272"/>
+      <point x="211" y="272" type="qcurve" smooth="yes"/>
+      <point x="230" y="272"/>
+      <point x="230" y="244" type="qcurve" smooth="yes"/>
+      <point x="230" y="-52" type="line"/>
+      <point x="278.186" y="-52" type="line"/>
+      <point x="243" y="1.07663"/>
+      <point x="243" y="78" type="qcurve" smooth="yes"/>
+      <point x="243" y="167"/>
+      <point x="337" y="281"/>
+    </contour>
+    <contour>
+      <point x="400" y="226" type="qcurve" smooth="yes"/>
+      <point x="363" y="226"/>
+      <point x="306" y="143"/>
+      <point x="306" y="13.0005"/>
+      <point x="363" y="-68.9995"/>
+      <point x="400" y="-69" type="qcurve" smooth="yes"/>
+      <point x="436" y="-69"/>
+      <point x="493" y="14.0005"/>
+      <point x="493" y="78" type="qcurve" smooth="yes"/>
+      <point x="493" y="143"/>
+      <point x="436" y="226"/>
+    </contour>
+  </outline>
+</glyph>


### PR DESCRIPTION
<img width="659" height="281" alt="image" src="https://github.com/user-attachments/assets/d57e0955-37f6-44f7-98db-d0155a493e4e" />
