### PR TITLE
Bake all references in the font (fixes #116)

### DIFF
--- a/APL387.ufo2/features.fea
+++ b/APL387.ufo2/features.fea
@@ -21,23 +21,23 @@ languagesystem tfng dflt;
 
 lookup ss01StyleSet1lookup1 {
   lookupflag 0;
-    sub \zero by \zero_ss01 ;
-    sub \uni2070 by \sup_zero_ss01 ;
-    sub \uni2080 by \sub_zero_ss01 ;
-    sub \uni23E8 by \uni23E8_ss01 ;
+    sub \zero by \zero.ss01 ;
+    sub \uni2070 by \uni2070.ss01 ;
+    sub \uni2080 by \uni2080.ss01 ;
+    sub \uni23E8 by \uni23E8.ss01 ;
 } ss01StyleSet1lookup1;
 
 lookup ss02StyleSet2lookup2 {
   lookupflag 0;
-    sub \uni236B by \obv_ss02 ;
-    sub \uni2371 by \nor_ss02 ;
-    sub \uni2372 by \nand_ss02 ;
+    sub \uni236B by \uni236B.ss02 ;
+    sub \uni2371 by \uni2371.ss02 ;
+    sub \uni2372 by \uni2372.ss02 ;
 } ss02StyleSet2lookup2;
 
 lookup cv01CharacterVariants01lookup0 {
   lookupflag 0;
-    sub \because by \because_cv01 ;
-    sub \therefore by \therefore_cv01 ;
+    sub \because by \because.cv01 ;
+    sub \therefore by \therefore.cv01 ;
 } cv01CharacterVariants01lookup0;
 
 feature ss01 {
@@ -920,16 +920,16 @@ feature mkmk {
 	\uni2508 \uni2509 \uni250B \uni254C \uni254D \uni254F \SF510000 \SF520000 
 	\SF220000 \SF210000 \SF500000 \SF490000 \SF280000 \SF270000 \uni256D \uni256E 
 	\uni256F \uni2570 \uni2571 \uni2572 \uni2573 \uni2596 \uni2597 \uni2598 \uni2599 
-	\uni259A \uni259B \uni259C \uni259D \uni259E \uni259F \because_cv01 
-	\therefore_cv01 \part_circle \part_star \part_dieresis \part_jot \part_stile 
+	\uni259A \uni259B \uni259C \uni259D \uni259E \uni259F \because.cv01 
+	\therefore.cv01 \part_circle \part_star \part_dieresis \part_jot \part_stile 
 	\part_shoe_left \part_shoe_down \part_shoe_right \part_shoe_up \part_tilde 
 	\part_underbar \part_over_tilde \part_del \part_wedge_left \part_wedge_down 
 	\part_wedge_right \part_wedge_up \part_epsilon \part_bar \part_overbar 
 	\part_tack_left \part_tack_down \part_tack_right \part_tack_up 
 	\part_cancel_45 \part_cancel_30 \part_cancel_mid \part_slash \part_backslash 
 	\part_diamond \part_quad \part_delta \part_dot_above \part_under_tilde 
-	\part_three_dots \part_mid_colon \zero_ss01 \sup_zero_ss01 \sub_zero_ss01 
-	\nand_ss02 \nor_ss02 \obv_ss02 \part_dot_below \uni222C \uni222E \uni2236 
+	\part_mid_colon \zero.ss01 \uni2070.ss01 \uni2080.ss01 \uni2372.ss02 
+	\uni2371.ss02 \uni236B.ss02 \part_dot_below \uni222C \uni222E \uni2236 
 	\uni2237 \uni2238 \uni2239 \uni223D \uni2240 \uni2241 \uni2250 \uni2254 \uni2255 
 	\uni2257 \uni2259 \uni225A \uni225B \uni226A \uni226B \uni226C \uni226D \uni226E 
 	\uni226F \uni2272 \uni2273 \uni2276 \uni2277 \uni2278 \uni2279 \notsubset 
@@ -951,14 +951,14 @@ feature mkmk {
 	\uni2242 \uni2243 \congruent \uni2246 \uni2247 \uni224A \uni224C \uni2251 
 	\uni2252 \uni2253 \uni225C \uni227A \uni227B \uni227C \uni227D \uni227E \uni227F 
 	\uni2280 \uni2281 \uni22CE \uni22CF \uni22DE \uni22DF \uni2AAA \uni2AAB \uni2AAC 
-	\uni2AAD \uni2AAF \uni2AB0 \uni214B \uni23E8_ss01 \part_plus 
+	\uni2AAD \uni2AAF \uni2AB0 \uni214B \uni23E8.ss01 \part_plus 
 	\part_epsilon_reversed \part_equals \part_box_left \part_box_down 
 	\part_box_right \part_box_up \part_times \part_arrow_left \part_arrow_down 
 	\part_arrow_right \part_arrow_up \part_quote \part_comma \part_semicolon 
 	\part_triangle_left \part_triangle_down \part_triangle_right 
 	\part_triangle_up \part_square \part_divide \part_parallel \part_equivalent 
 	\part_tri \part_angle \part_curly_wedge_left \part_curly_wedge_down 
-	\part_curly_wedge_right \part_curly_wedge_up ];
+	\part_curly_wedge_right \part_curly_wedge_up \part_three_dots ];
 @GDEF_Mark = [\gravecomb \acutecomb \uni0302 \tildecomb \uni0304 \uni0305 \uni0306 
 	\uni0307 \uni0308 \uni030A \uni030B \uni030C \uni0326 \uni0327 \uni0328 
 	\uni0302.alt01 \uni0304.alt01 \uni0308.case \uni0307.case \gravecomb.case 

--- a/APL387.ufo2/fontinfo.plist
+++ b/APL387.ufo2/fontinfo.plist
@@ -29,7 +29,7 @@
     <key>italicAngle</key>
     <real>0</real>
     <key>openTypeHeadCreated</key>
-    <string>2026/05/29 11:49:50</string>
+    <string>2026/06/03 11:48:34</string>
     <key>openTypeHheaAscender</key>
     <integer>910</integer>
     <key>openTypeHheaDescender</key>

--- a/APL387.ufo2/glyphs/because_cv01.glif
+++ b/APL387.ufo2/glyphs/because_cv01.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="because_cv01" format="1">
+<glyph name="because.cv01" format="1">
   <advance width="600"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/contents.plist
+++ b/APL387.ufo2/glyphs/contents.plist
@@ -2514,9 +2514,9 @@
     <string>uni259E_.glif</string>
     <key>uni259F</key>
     <string>uni259F_.glif</string>
-    <key>because_cv01</key>
+    <key>because.cv01</key>
     <string>because_cv01.glif</string>
-    <key>therefore_cv01</key>
+    <key>therefore.cv01</key>
     <string>therefore_cv01.glif</string>
     <key>part_circle</key>
     <string>part_circle.glif</string>
@@ -2586,21 +2586,19 @@
     <string>part_dot_above.glif</string>
     <key>part_under_tilde</key>
     <string>part_under_tilde.glif</string>
-    <key>part_three_dots</key>
-    <string>part_three_dots.glif</string>
     <key>part_mid_colon</key>
     <string>part_mid_colon.glif</string>
-    <key>zero_ss01</key>
+    <key>zero.ss01</key>
     <string>zero_ss01.glif</string>
-    <key>sup_zero_ss01</key>
+    <key>uni2070.ss01</key>
     <string>sup_zero_ss01.glif</string>
-    <key>sub_zero_ss01</key>
+    <key>uni2080.ss01</key>
     <string>sub_zero_ss01.glif</string>
-    <key>nand_ss02</key>
+    <key>uni2372.ss02</key>
     <string>nand_ss02.glif</string>
-    <key>nor_ss02</key>
+    <key>uni2371.ss02</key>
     <string>nor_ss02.glif</string>
-    <key>obv_ss02</key>
+    <key>uni236B.ss02</key>
     <string>obv_ss02.glif</string>
     <key>part_dot_below</key>
     <string>part_dot_below.glif</string>
@@ -2958,7 +2956,7 @@
     <string>uni2A_B_0.glif</string>
     <key>uni214B</key>
     <string>uni214B_.glif</string>
-    <key>uni23E8_ss01</key>
+    <key>uni23E8.ss01</key>
     <string>uni23E_8_ss01.glif</string>
     <key>part_plus</key>
     <string>part_plus.glif</string>
@@ -3018,5 +3016,7 @@
     <string>part_curly_wedge_right.glif</string>
     <key>part_curly_wedge_up</key>
     <string>part_curly_wedge_up.glif</string>
+    <key>part_three_dots</key>
+    <string>part_three_dots.glif</string>
   </dict>
 </plist>

--- a/APL387.ufo2/glyphs/nand_ss02.glif
+++ b/APL387.ufo2/glyphs/nand_ss02.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="nand_ss02" format="1">
+<glyph name="uni2372.ss02" format="1">
   <advance width="600"/>
   <outline>
     <component base="part_tilde"/>

--- a/APL387.ufo2/glyphs/nor_ss02.glif
+++ b/APL387.ufo2/glyphs/nor_ss02.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="nor_ss02" format="1">
+<glyph name="uni2371.ss02" format="1">
   <advance width="600"/>
   <outline>
     <component base="part_wedge_down"/>

--- a/APL387.ufo2/glyphs/obv_ss02.glif
+++ b/APL387.ufo2/glyphs/obv_ss02.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="obv_ss02" format="1">
+<glyph name="uni236B.ss02" format="1">
   <advance width="600"/>
   <outline>
     <component base="part_del"/>

--- a/APL387.ufo2/glyphs/part_epsilon_reversed.glif
+++ b/APL387.ufo2/glyphs/part_epsilon_reversed.glif
@@ -6,23 +6,19 @@
       <point x="80" y="536" type="qcurve" smooth="yes"/>
       <point x="80" y="498"/>
       <point x="112" y="498" type="qcurve" smooth="yes"/>
-      <point x="112" y="498"/>
-      <point x="206" y="498" type="qcurve" smooth="yes"/>
+      <point x="206" y="498" type="line" smooth="yes"/>
       <point x="438" y="498"/>
       <point x="438" y="370" type="qcurve"/>
-      <point x="438" y="370"/>
-      <point x="148" y="370" type="qcurve" smooth="yes"/>
+      <point x="148" y="370" type="line" smooth="yes"/>
       <point x="100" y="370"/>
       <point x="100" y="290"/>
       <point x="148" y="290" type="qcurve" smooth="yes"/>
-      <point x="148" y="290"/>
-      <point x="437" y="290" type="qcurve"/>
+      <point x="437" y="290" type="line"/>
       <point x="438" y="289" type="line"/>
       <point x="427" y="225"/>
       <point x="322" y="163"/>
       <point x="206" y="163" type="qcurve" smooth="yes"/>
-      <point x="206" y="163"/>
-      <point x="132" y="163" type="qcurve" smooth="yes"/>
+      <point x="132" y="163" type="line" smooth="yes"/>
       <point x="105" y="163"/>
       <point x="80" y="147"/>
       <point x="80" y="126" type="qcurve" smooth="yes"/>

--- a/APL387.ufo2/glyphs/part_three_dots.glif
+++ b/APL387.ufo2/glyphs/part_three_dots.glif
@@ -3,90 +3,68 @@
   <advance width="600"/>
   <outline>
     <contour>
-      <point x="537.5" y="441.774" type="qcurve" smooth="yes"/>
-      <point x="537.5" y="441.487"/>
-      <point x="537.434" y="440.437"/>
-      <point x="537.43" y="440.2" type="qcurve" smooth="yes"/>
-      <point x="537.408" y="438.379"/>
-      <point x="537.238" y="435.999" type="qcurve" smooth="yes"/>
-      <point x="537.111" y="434.166"/>
-      <point x="536.787" y="431.335"/>
-      <point x="536.541" y="429.813" type="qcurve" smooth="yes"/>
-      <point x="534.458" y="416.004"/>
-      <point x="527.422" y="404.335" type="qcurve" smooth="yes"/>
-      <point x="527.167" y="403.833"/>
-      <point x="527.107" y="403.729" type="qcurve" smooth="yes"/>
-      <point x="526.778" y="403.16"/>
-      <point x="525.443" y="401.127"/>
-      <point x="525.332" y="400.952" type="qcurve" smooth="yes"/>
-      <point x="510.099" y="377.186"/>
-      <point x="482.488" y="369.446" type="qcurve" smooth="yes"/>
-      <point x="452.869" y="361.144"/>
-      <point x="426.023" y="376.644" type="qcurve" smooth="yes"/>
-      <point x="407.475" y="387.351"/>
-      <point x="398.029" y="405.222" type="qcurve" smooth="yes"/>
-      <point x="388.5" y="421.577"/>
-      <point x="388.5" y="441.774" type="qcurve" smooth="yes"/>
-      <point x="388.5" y="472.773"/>
-      <point x="432.5" y="515.774"/>
-      <point x="462.5" y="515.774" type="qcurve" smooth="yes"/>
-      <point x="462.789" y="515.774"/>
-      <point x="463.844" y="515.708"/>
-      <point x="464.082" y="515.704" type="qcurve" smooth="yes"/>
-      <point x="470.633" y="515.732"/>
-      <point x="477.24" y="514.458" type="qcurve" smooth="yes"/>
-      <point x="477.588" y="514.396" type="line" smooth="yes"/>
-      <point x="480.059" y="513.905"/>
-      <point x="482.615" y="513.196" type="qcurve" smooth="yes"/>
-      <point x="484.492" y="512.701"/>
-      <point x="486.221" y="512.147" type="qcurve" smooth="yes"/>
-      <point x="486.896" y="511.92"/>
-      <point x="487.646" y="511.651" type="qcurve" smooth="yes"/>
-      <point x="497.33" y="508.322"/>
-      <point x="505.795" y="502.312" type="qcurve" smooth="yes"/>
-      <point x="507.144" y="501.391"/>
-      <point x="509.416" y="499.64" type="qcurve" smooth="yes"/>
-      <point x="509.511" y="499.563"/>
-      <point x="509.721" y="499.403" type="qcurve" smooth="yes"/>
-      <point x="518.641" y="492.377"/>
-      <point x="524.59" y="483.628" type="qcurve" smooth="yes"/>
-      <point x="524.933" y="483.145"/>
-      <point x="525.719" y="481.97" type="qcurve" smooth="yes"/>
-      <point x="526.606" y="480.577"/>
-      <point x="527.096" y="479.741" type="qcurve" smooth="yes"/>
-      <point x="536.346" y="464.701"/>
-      <point x="537.305" y="446.099" type="qcurve" smooth="yes"/>
-      <point x="537.323" y="445.837"/>
-      <point x="537.341" y="445.36" type="qcurve" smooth="yes"/>
-      <point x="537.378" y="444.413"/>
-      <point x="537.5" y="442.351"/>
+      <point x="461.995" y="367.773" type="line" smooth="yes"/>
+      <point x="431.5" y="367.774"/>
+      <point x="409.73" y="389.049" type="qcurve" smooth="yes"/>
+      <point x="387.5" y="410.773"/>
+      <point x="387.5" y="441.751" type="qcurve" smooth="yes"/>
+      <point x="387.5" y="441.752" type="line" smooth="yes"/>
+      <point x="387.5" y="472.773"/>
+      <point x="409.738" y="494.506" type="qcurve" smooth="yes"/>
+      <point x="431.5" y="515.774"/>
+      <point x="461.985" y="515.774" type="qcurve" smooth="yes"/>
+      <point x="492.5" y="515.774"/>
+      <point x="514.274" y="494.494" type="qcurve" smooth="yes"/>
+      <point x="536.5" y="472.773"/>
+      <point x="536.5" y="410.774"/>
+      <point x="514.287" y="389.065" type="qcurve" smooth="yes"/>
+      <point x="492.501" y="367.773"/>
+      <point x="461.996" y="367.773" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="374.453" y="156.118" type="qcurve" smooth="yes"/>
-      <point x="373.797" y="138.184"/>
-      <point x="364.107" y="121.405" type="qcurve" smooth="yes"/>
+      <point x="372.066" y="177.756" type="qcurve" smooth="yes"/>
+      <point x="374.562" y="167.99"/>
+      <point x="374.562" y="158.564" type="qcurve" smooth="yes"/>
+      <point x="374.562" y="139.508"/>
+      <point x="364.359" y="121.839" type="qcurve" smooth="yes"/>
       <point x="349.107" y="95.4248"/>
-      <point x="289.869" y="78.8193"/>
+      <point x="319.796" y="87.2085" type="qcurve" smooth="yes"/>
+      <point x="309.282" y="84.2611"/>
+      <point x="299.15" y="84.2611" type="qcurve" smooth="yes"/>
+      <point x="280.444" y="84.2611"/>
+      <point x="263.042" y="94.3081" type="qcurve" smooth="yes"/>
       <point x="236.177" y="109.819"/>
-      <point x="220.937" y="169.424"/>
-      <point x="235.938" y="195.405" type="qcurve" smooth="yes"/>
+      <point x="228.475" y="139.944" type="qcurve" smooth="yes"/>
+      <point x="225.981" y="149.698"/>
+      <point x="225.981" y="159.115" type="qcurve" smooth="yes"/>
+      <point x="225.981" y="178.16"/>
+      <point x="236.18" y="195.826" type="qcurve" smooth="yes"/>
       <point x="251.437" y="222.251"/>
-      <point x="310.676" y="238.857"/>
+      <point x="280.762" y="230.472" type="qcurve" smooth="yes"/>
+      <point x="291.264" y="233.415"/>
+      <point x="301.387" y="233.415" type="qcurve" smooth="yes"/>
+      <point x="320.101" y="233.415"/>
+      <point x="337.523" y="223.356" type="qcurve" smooth="yes"/>
       <point x="364.37" y="207.855"/>
-      <point x="371.988" y="178.054" type="qcurve" smooth="yes"/>
-      <point x="374.847" y="166.874"/>
     </contour>
     <contour>
-      <point x="136.5" y="367.774" type="qcurve" smooth="yes"/>
+      <point x="136.995" y="367.774" type="line" smooth="yes"/>
       <point x="106.5" y="367.774"/>
-      <point x="62.4995" y="410.774"/>
+      <point x="84.7301" y="389.049" type="qcurve" smooth="yes"/>
+      <point x="62.4997" y="410.774"/>
+      <point x="62.4997" y="441.751" type="qcurve" smooth="yes"/>
+      <point x="62.4997" y="441.752" type="line" smooth="yes"/>
       <point x="62.5" y="472.773"/>
+      <point x="84.7379" y="494.506" type="qcurve" smooth="yes"/>
       <point x="106.5" y="515.774"/>
-      <point x="136.5" y="515.774" type="qcurve" smooth="yes"/>
+      <point x="136.986" y="515.774" type="qcurve" smooth="yes"/>
       <point x="167.5" y="515.774"/>
+      <point x="189.275" y="494.494" type="qcurve" smooth="yes"/>
       <point x="211.5" y="472.773"/>
       <point x="211.5" y="410.774"/>
-      <point x="167.5" y="367.773"/>
+      <point x="189.287" y="389.065" type="qcurve" smooth="yes"/>
+      <point x="167.501" y="367.774"/>
+      <point x="136.996" y="367.774" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/APL387.ufo2/glyphs/sub_zero_ss01.glif
+++ b/APL387.ufo2/glyphs/sub_zero_ss01.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="sub_zero_ss01" format="1">
+<glyph name="uni2080.ss01" format="1">
   <advance width="600"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/sup_zero_ss01.glif
+++ b/APL387.ufo2/glyphs/sup_zero_ss01.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="sup_zero_ss01" format="1">
+<glyph name="uni2070.ss01" format="1">
   <advance width="600"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/therefore_cv01.glif
+++ b/APL387.ufo2/glyphs/therefore_cv01.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="therefore_cv01" format="1">
+<glyph name="therefore.cv01" format="1">
   <advance width="600"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/uni23E_8_ss01.glif
+++ b/APL387.ufo2/glyphs/uni23E_8_ss01.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="uni23E8_ss01" format="1">
+<glyph name="uni23E8.ss01" format="1">
   <advance width="600"/>
   <outline>
     <contour>

--- a/APL387.ufo2/glyphs/zero_ss01.glif
+++ b/APL387.ufo2/glyphs/zero_ss01.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glyph name="zero_ss01" format="1">
+<glyph name="zero.ss01" format="1">
   <advance width="600"/>
   <outline>
     <contour>

--- a/script.py
+++ b/script.py
@@ -361,6 +361,8 @@ w←⊃(⊃0⍴⍵){
 </html>		 
     ''')
 
+for glyph in apl387.glyphs(): glyph.unlinkRef()
+
 def bake_feature(lookup: str):
   subtable = apl387.getLookupSubtables(lookup)[0]
   to_swap = []
@@ -411,7 +413,7 @@ index_page('APL385', 'APL387')
 apl335 = apl387 # no need to clone, original font isn't needed anymore
 
 for glyph in apl335.glyphs():
-	if glyph.unicode == -1: continue # ignore parts
+	if glyph.glyphname.startswith('part_'): continue # ignore parts
 	glyph.left_side_bearing = 50
 	glyph.right_side_bearing = 50
    


### PR DESCRIPTION
While references are great for editing the font, they aren't as supported across renderers and sometimes also seem to confuse FontForge itself.

Also renames character variations to follow standard of `glyphname.stylisticset`

Fixes #88 